### PR TITLE
Print invalid relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactor scope calls to be more DRY.
 - Fix checking if an attribute exists.
 - Create a hook for the controller to mutate search values (e.g. for date formatting) (https://hitower.atlassian.net/browse/WEAP-187).
+- Print any invalid relation names in the exception.
 
 ## v0.0.15
 - Return only the pagination keys if the request is paginated.

--- a/src/Http/Controllers/Validators/Relations.php
+++ b/src/Http/Controllers/Validators/Relations.php
@@ -30,14 +30,14 @@ class Relations
             return $relations->all();
         }
 
-        $relationsAreValid = $relations->every(function ($callback, $relation) use ($availableRelations) {
+        $invalidRelations = $relations->filter(function ($callback, $relation) use ($availableRelations) {
             $key = is_string($callback) ? $callback : $relation;
 
-            return array_key_exists($key, $availableRelations) || in_array($key, $availableRelations);
+            return ! array_key_exists($key, $availableRelations) && ! in_array($key, $availableRelations);
         });
 
-        throw_if(! $relationsAreValid, ValidationException::withMessages([
-            'relations' => 'Invalid relations'
+        throw_if($invalidRelations->isNotEmpty(), ValidationException::withMessages([
+            'relations' => "Invalid relation(s): {$invalidRelations->join(', ')}",
         ]));
 
         return $relations->all();


### PR DESCRIPTION
Add the names of the invalid relations when throwing the exception. This makes it easier to debug any mistakes in the client code or any need to add more allowed relations.

This should not pose any security risks, as an attacker can already find out if a relation is invalid by trial and error.