### PR TITLE
Fixed bug where `morphTo` relations in `where`, `whereIn`, `whereNotIn` and `search` filters would throw an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Fixed bug where `morphTo` relations in `where`, `whereIn`, `whereNotIn` and `search` filters would throw an error.
+- Deprecated `getRelationTableName` method on `Weap\Junction\Http\Controllers\Helpers\Table` class because it gives the wrong results for `morphTo` relations.
 
 ## v0.1.1
 - Media temporary upload `beforeMediaUpload` & `afterMediaUpload` hooks.

--- a/src/Http/Controllers/Filters/WhereIn.php
+++ b/src/Http/Controllers/Filters/WhereIn.php
@@ -4,6 +4,7 @@ namespace Weap\Junction\Http\Controllers\Filters;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
 use Weap\Junction\Http\Controllers\Helpers\Table;
@@ -45,16 +46,19 @@ class WhereIn extends Filter
         // Directly on the main model (no relation)
         if (count($relationParts) === 1) {
             $query->whereIn($query->getModel()->getTable() . '.' . $column, $values);
+
             return;
         }
 
         // Treatment for columns in a relationship
         $actualColumn = array_pop($relationParts);
         $relationPath = implode('.', $relationParts);
-        $tableName = Table::getRelationTableName($query->getModel()::class, $relationParts);
+        $relation = Table::getRelation($query->getModel()::class, $relationParts);
 
-        $query->whereHas($relationPath, function ($subQuery) use ($actualColumn, $values, $tableName) {
+        $query->whereHas($relationPath, function (Builder $subQuery) use ($actualColumn, $values, $relation) {
+            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $subQuery->from;
             $fullColumn = $tableName . '.' . $actualColumn;
+
             $subQuery->whereIn($fullColumn, $values);
         });
     }

--- a/src/Http/Controllers/Filters/Wheres.php
+++ b/src/Http/Controllers/Filters/Wheres.php
@@ -4,6 +4,7 @@ namespace Weap\Junction\Http\Controllers\Filters;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use RuntimeException;
 use Weap\Junction\Http\Controllers\Controller;
@@ -57,10 +58,11 @@ class Wheres extends Filter
 
         $actualColumn = array_pop($columnParts);
         $relationPath = implode('.', $columnParts);
-        $tableName = Table::getRelationTableName($query->getModel()::class, $columnParts);
+        $relation = Table::getRelation($query->getModel()::class, $columnParts);
 
-        $query->whereHas($relationPath, function ($innerQuery) use ($actualColumn, $operator, $value, $tableName) {
-            $fullColumn = $tableName ? $tableName . '.' . $actualColumn : $actualColumn;
+        $query->whereHas($relationPath, function (Builder $innerQuery) use ($actualColumn, $operator, $value, $relation) {
+            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $innerQuery->from;
+            $fullColumn = $tableName . '.' . $actualColumn;
 
             static::applyWhere($innerQuery, $fullColumn, $operator, $value);
         });

--- a/src/Http/Controllers/Helpers/Table.php
+++ b/src/Http/Controllers/Helpers/Table.php
@@ -3,31 +3,44 @@
 namespace Weap\Junction\Http\Controllers\Helpers;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class Table
 {
     /**
+     * @deprecated This function gives wrong table name for `morphTo` relation.
+     *
      * @param string $model
      * @param array $relations
      * @return string
      */
     public static function getRelationTableName(string $model, array $relations): string
     {
-        if (count($relations) > 1) {
-            $relation = array_shift($relations);
-
-            return static::getRelationTableName(
-                (new $model())->$relation()->newModelInstance()::class,
-                $relations
-            );
-        }
-
-        $relation = (new $model())->{$relations[0]}();
+        $relation = static::getRelation($model, $relations);
 
         if ($relation instanceof BelongsToMany) {
             return $relation->getTable();
         }
 
         return $relation->newModelInstance()->getTable();
+    }
+
+    /**
+     * @param string $model
+     * @param array $relations
+     * @return Relation
+     */
+    public static function getRelation(string $model, array $relations): Relation
+    {
+        if (count($relations) > 1) {
+            $relation = array_shift($relations);
+
+            return static::getRelation(
+                (new $model())->$relation()->newModelInstance()::class,
+                $relations
+            );
+        }
+
+        return (new $model())->{$relations[0]}();
     }
 }


### PR DESCRIPTION
closes #42 