### PR TITLE
Eager appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added support for eager loads in accessors.
+- Relations of dot-notated *appends* are now eager loaded.
 
 ## v0.2.3
 - Laravel 12 support.

--- a/src/Http/Controllers/Filters/Relations.php
+++ b/src/Http/Controllers/Filters/Relations.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Weap\Junction\Http\Controllers\Controller;
 use Weap\Junction\Http\Controllers\Validators\Relations as RelationsValidator;
+use Weap\Junction\Junction;
 
 class Relations extends Filter
 {
@@ -79,8 +80,8 @@ class Relations extends Filter
                 $accessor = Str::camel($accessor);
                 $attribute = method_exists($query->getModel(), $accessor) ? $query->getModel()::$accessor() : null;
 
-                if ($attribute instanceof Attribute && property_exists($attribute, 'with')) {
-                    $nestedRelations += $attribute->with;
+                if ($attribute instanceof Attribute && ($with = Junction::$cachedAttributeRelations[$query->getModel()::class][$accessor] ?? null)) {
+                    $nestedRelations += $with;
                 }
             }
 

--- a/src/Http/Controllers/Modifiers/Appends.php
+++ b/src/Http/Controllers/Modifiers/Appends.php
@@ -17,7 +17,7 @@ class Appends extends Modifier
      */
     public static function apply(Controller $controller, Response $response): void
     {
-        $appends = request()?->input('appends');
+        $appends = request()?->getAccessors();
 
         if (! $appends) {
             return;

--- a/src/Http/Controllers/Traits/HasIndex.php
+++ b/src/Http/Controllers/Traits/HasIndex.php
@@ -67,9 +67,9 @@ trait HasIndex
 
         $this->afterIndex($items);
 
-        $pluckFields = request()?->input('pluck');
-        $accessors = request()?->input('appends');
-        $relations = request()?->input('with');
+        $pluckFields = request()?->getPluckFields();
+        $accessors = request()?->getAccessors();
+        $relations = request()?->getRelations();
 
         return $this->resource::items(
             $items,

--- a/src/Http/Controllers/Traits/HasShow.php
+++ b/src/Http/Controllers/Traits/HasShow.php
@@ -60,9 +60,9 @@ trait HasShow
 
         $this->afterShow($item);
 
-        $pluckFields = request()?->input('pluck');
-        $accessors = request()?->input('appends');
-        $relations = request()?->input('with');
+        $pluckFields = request()?->getPluckFields();
+        $accessors = request()?->getAccessors();
+        $relations = request()?->getRelations();
 
         $this->resource::withoutWrapping();
 

--- a/src/Junction.php
+++ b/src/Junction.php
@@ -2,11 +2,9 @@
 
 namespace Weap\Junction;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Facades\Route;
 
-/**
- * @deprecated Junction::resource are replaced by Route::junctionResource.
- */
 class Junction
 {
     /**
@@ -14,9 +12,26 @@ class Junction
      * @param $controller
      * @param mixed $only
      * @return void
+     *
+     * @deprecated Replaced by Route::junctionResource().
      */
     public static function resource($uri, $controller, $only = ['index', 'indexPost', 'store', 'show', 'showPost', 'update', 'destroy', 'action']): void
     {
         Route::junctionResource($uri, $controller)->only($only);
+    }
+
+    /**
+     * @param callable|null $get
+     * @param callable|null $set
+     * @param array $with
+     * @return Attribute
+     */
+    public static function makeAttribute(?callable $get = null, ?callable $set = null, array $with = []): Attribute
+    {
+        $attribute = Attribute::make($get, $set);
+
+        $attribute->with = $with;
+
+        return $attribute;
     }
 }

--- a/src/Junction.php
+++ b/src/Junction.php
@@ -2,11 +2,17 @@
 
 namespace Weap\Junction;
 
+use Closure;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Facades\Route;
 
 class Junction
 {
+    /**
+     * @var array<class-string, array<string, array<string|int, string|Closure>>>
+     */
+    public static array $cachedAttributeRelations = [];
+
     /**
      * @param $uri
      * @param $controller
@@ -30,7 +36,9 @@ class Junction
     {
         $attribute = Attribute::make($get, $set);
 
-        $attribute->with = $with;
+        if ($caller = debug_backtrace()[1] ?? null) {
+            static::$cachedAttributeRelations[$caller['class']][$caller['function']] ??= $with;
+        }
 
         return $attribute;
     }


### PR DESCRIPTION
Alternative fix for https://github.com/weapnl/laravel-junction/issues/51

### Accessors
To append accessors to models in the response, you can use the `appends` modifier. This modifier allows dot-notation for relations. These relations will be eager loaded (relation closures defined in the controller are applied as well).

In some cases you may want an accessor to return a value of one of its relations, which would normally cause a lazy load when the accessor is executed. To eager load the relation, you could add it to the request using the `with` filter, which means the frontend is responsible for proper eager loading.
To shift this responsibility to the backend, you can use the `Junction::makeAttribute()` function to make an accessor instead of `Attribute::make()`:

```php
use Weap\Junction\Junction;

/**
 * @return Attribute<string, never>
 */
protected function name(): Attribute
{
    return Junction::makeAttribute(
        get: fn (): string => $this->contact->name,
        with: ['contact'],
    );
}
```

In this case, the `contact` relation would be eager loaded before the accessor is executed, which can prevent N+1 queries. The `with` array also allows dot-notation and closures to customize the query:

```php
use Weap\Junction\Junction;

/**
 * @return Attribute<string, never>
 */
protected function name(): Attribute
{
    return Junction::makeAttribute(
        get: function (): string {
            return match ($this->subjectable::class) {
                Employee::class => $this->subjectable->contact?->name,
                Freelancer::class => $this->subjectable->company?->name,
                default => null,
            } ?: '';
        },
        with: [
            'subjectable' => function ($query) {
                $query->morphWith([
                    Employee::class => ['contact'],
                    Freelancer::class => ['company'],
                ]);
            },
        ],
    );
}
```