### PR TITLE
Parent relations are now implicitly allowed when defined via nested relations in relations() method

### DIFF
--- a/src/Http/Controllers/Validators/Relations.php
+++ b/src/Http/Controllers/Validators/Relations.php
@@ -2,6 +2,7 @@
 
 namespace Weap\Junction\Http\Controllers\Validators;
 
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 use Weap\Junction\Http\Controllers\Controller;
 
@@ -31,10 +32,16 @@ class Relations
             return $relations->all();
         }
 
-        $invalidRelations = $relations->filter(function ($callback, $relation) use ($availableRelations) {
+        $availableRelationsUndotted = Arr::undot(array_flip($availableRelations));
+        $invalidRelations = $relations->filter(function ($callback, $relation) use ($availableRelations, $availableRelationsUndotted) {
             $key = is_string($callback) ? $callback : $relation;
 
-            return ! array_key_exists($key, $availableRelations) && ! in_array($key, $availableRelations);
+            // Direct match
+            if (in_array($key, $availableRelations)) {
+                return false;
+            }
+
+            return ! Arr::has($availableRelationsUndotted, $key);
         });
 
         throw_if($invalidRelations->isNotEmpty(), ValidationException::withMessages([


### PR DESCRIPTION
When defining allowed relations in the relations(): array method of a controller, adding a nested relation such as orderItems.product did not automatically permit the parent relation orderItems. This caused validation to fail when the frontend requested with=orderItems, even though it was logically included as part of the nested relation.

Fix:

The relations() method now automatically includes parent relations of any nested relations defined in its return value. For example, if orderItems.product is present, orderItems will now also be allowed implicitly.