### PR TITLE
Octane compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Replaced static `Junction::$cachedAttributeRelations` with request-scoped `AttributeRelationCache` for Laravel Octane compatibility.
 
 ## v0.4.0
 - Fixed bug where eager loads in accessors would not work if no other relations were requested.

--- a/src/AttributeRelationCache.php
+++ b/src/AttributeRelationCache.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Weap\Junction;
+
+class AttributeRelationCache
+{
+    /**
+     * @var array
+     */
+    protected array $relations = [];
+
+    /**
+     * @param string $class
+     * @param string $function
+     * @param array $with
+     * @return void
+     */
+    public function set(string $class, string $function, array $with): void
+    {
+        $this->relations[$class][$function] ??= $with;
+    }
+
+    /**
+     * @param string $class
+     * @param string $function
+     * @return array|null
+     */
+    public function get(string $class, string $function): ?array
+    {
+        return $this->relations[$class][$function] ?? null;
+    }
+}

--- a/src/Http/Controllers/Filters/Relations.php
+++ b/src/Http/Controllers/Filters/Relations.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionMethod;
+use Weap\Junction\AttributeRelationCache;
 use Weap\Junction\Http\Controllers\Controller;
 use Weap\Junction\Http\Controllers\Validators\Relations as RelationsValidator;
 use Weap\Junction\Junction;
@@ -93,7 +94,9 @@ class Relations extends Filter
                 continue;
             }
 
-            if ($attribute instanceof Attribute && ($with = Junction::$cachedAttributeRelations[$modelClass][$accessor] ?? null)) {
+            $cache = app(AttributeRelationCache::class);
+
+            if ($attribute instanceof Attribute && ($with = $cache->get($modelClass, $accessor))) {
                 $relations += Arr::mapWithKeys($with, fn ($relation, $key) => is_callable($relation) ? [$key => $relation] : [$relation => $key]);
             }
         }

--- a/src/Junction.php
+++ b/src/Junction.php
@@ -37,7 +37,9 @@ class Junction
         $attribute = Attribute::make($get, $set);
 
         if ($caller = debug_backtrace()[1] ?? null) {
-            static::$cachedAttributeRelations[$caller['class']][$caller['function']] ??= $with;
+            /** @var AttributeRelationCache $cache */
+            $attributeRelationCache = app(AttributeRelationCache::class);
+            $attributeRelationCache->set($caller['class'], $caller['function'], $with);
         }
 
         return $attribute;

--- a/src/JunctionServiceProvider.php
+++ b/src/JunctionServiceProvider.php
@@ -39,6 +39,8 @@ class JunctionServiceProvider extends ServiceProvider
         $this->bootRouteMacros();
 
         $this->bootRequestMacros();
+
+        $this->app->scoped(AttributeRelationCache::class, fn () => new AttributeRelationCache());
     }
 
     /**


### PR DESCRIPTION
Replaced static `Junction::$cachedAttributeRelations` with request-scoped `AttributeRelationCache` for Laravel Octane compatibility.