### PR TITLE
Use resource class for store, update and destroy responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Use resource class for store, update, and destroy responses, ensuring consistent output and applying availableAttributes and availableRelations filters.
 
 ## v0.4.7
 - Added Laravel 13 support.

--- a/src/Http/Controllers/Traits/HasDestroy.php
+++ b/src/Http/Controllers/Traits/HasDestroy.php
@@ -40,7 +40,7 @@ trait HasDestroy
             return $this->afterDestroy($model);
         });
 
-        return response()->json($model);
+        return response()->json(new $this->resource($model));
     }
 
     /**

--- a/src/Http/Controllers/Traits/HasStore.php
+++ b/src/Http/Controllers/Traits/HasStore.php
@@ -44,7 +44,7 @@ trait HasStore
             return $this->afterStore($model, $validAttributes, $invalidAttributes);
         });
 
-        return response()->json($model);
+        return response()->json(new $this->resource($model));
     }
 
     /**

--- a/src/Http/Controllers/Traits/HasUpdate.php
+++ b/src/Http/Controllers/Traits/HasUpdate.php
@@ -54,7 +54,7 @@ trait HasUpdate
             return $this->afterUpdate($model, $validAttributes, $invalidAttributes);
         });
 
-        return response()->json($model);
+        return response()->json(new $this->resource($model));
     }
 
     /**


### PR DESCRIPTION
Previously, store, update and destroy returned the raw model as JSON, bypassing the resource class. This meant any availableAttributes or availableRelations filtering on the resource was ignored for these endpoints.

Now all three use the same $resource class that index and show already use, so the response format is consistent across all endpoints.