### PR TITLE
Render loaded relations when no pluck relations are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Use resource class for store, update, and destroy responses, ensuring consistent output and applying availableAttributes and availableRelations filters.
 - Validate that `id` is required for actions expecting a model, preventing 500 TypeErrors and returning a proper 422 validation error instead.
+- `BaseResource` now falls back to rendering `availableRelations` that are already loaded on the model when no pluck relations are provided (e.g. in store/update responses), mirroring Laravel's `whenLoaded` behaviour.
 
 ## v0.4.7
 - Added Laravel 13 support.

--- a/src/Http/Controllers/Resources/BaseResource.php
+++ b/src/Http/Controllers/Resources/BaseResource.php
@@ -93,22 +93,35 @@ class BaseResource extends JsonResource
      */
     protected function relationsToArray(Request $request): array
     {
-        $relations = $this->availableRelations();
+        $availableRelations = $this->availableRelations();
 
-        // If no pluck relations are given, return nothing
+        // If no pluck relations are given, fall back to rendering the available
+        // relations that are already loaded on the model. This keeps store/update
+        // responses consistent with Laravel's `whenLoaded` behaviour.
         if ($this->pluckRelations === null) {
-            return [];
-        }
+            if ($availableRelations === null) {
+                return [];
+            }
 
-        // Only get available relations (if present)
-        $relations = $relations !== null
-            ? collect($relations)->filter(fn ($resource, $field) => array_key_exists($field, $this->pluckRelations))
-            : collect($this->pluckRelations)->mapWithKeys(fn ($_, $relation) => [$relation => self::class]);
+            $relations = collect($availableRelations)
+                ->filter(fn ($_, $field) => $this->resource->relationLoaded($field));
+
+            if ($relations->isEmpty()) {
+                return [];
+            }
+        } else {
+            // Only get available relations (if present)
+            $relations = $availableRelations !== null
+                ? collect($availableRelations)->filter(fn ($resource, $field) => array_key_exists($field, $this->pluckRelations))
+                : collect($this->pluckRelations)->mapWithKeys(fn ($_, $relation) => [$relation => self::class]);
+        }
 
         return $relations->map(function ($resourceClass, $field) use ($request) {
             if ($this->resource->$field === null) {
                 return null;
             }
+
+            $nestedPluckRelations = is_array($this->pluckRelations[$field] ?? null) ? $this->pluckRelations[$field] : null;
 
             if ($this->resource->$field instanceof Collection) {
                 $resourceCollection = $resourceClass::collection($this->resource->$field);
@@ -117,7 +130,7 @@ class BaseResource extends JsonResource
                 $resourceCollection->resource->each->pluckFields(
                     $this->pluckAttributes[$field] ?? null,
                     $this->pluckAccessors[$field] ?? null,
-                    is_array($this->pluckRelations[$field] ?? null) ? $this->pluckRelations[$field] : null,
+                    $nestedPluckRelations,
                 );
 
                 return $resourceCollection->toArray($request);
@@ -128,7 +141,7 @@ class BaseResource extends JsonResource
             $resource->pluckFields(
                 $this->pluckAttributes[$field] ?? null,
                 $this->pluckAccessors[$field] ?? null,
-                is_array($this->pluckRelations[$field] ?? null) ? $this->pluckRelations[$field] : null,
+                $nestedPluckRelations,
             );
 
             return $resource->toArray($request);


### PR DESCRIPTION
`BaseResource` now falls back to rendering `availableRelations` that are loaded on the model when `pluckRelations` is `null`, mirroring Laravel's `whenLoaded` behaviour. Fixes `HasStore` / `HasUpdate` responses silently dropping relations loaded in `afterStore` /`afterUpdate`.