### PR TITLE
Fix: use table alias for self-referential relations in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed a bug where filtering through a self-referential relation (search, where, whereIn, whereNotIn) generated invalid SQL, because the related model's aliased table name (`table as alias`) was used as a column prefix instead of the alias.
 
 ## v0.6.0
 - Bumped dependencies which fix vulnerability issues.

--- a/src/Http/Controllers/Filters/Search.php
+++ b/src/Http/Controllers/Filters/Search.php
@@ -58,7 +58,7 @@ class Search extends Filter
                 $relation = Table::getRelation($query->getModel()::class, [$relationName]);
 
                 $query->orWhereHas($relationName, function (Builder $query) use ($relationColumns, $relation, $searchValue) {
-                    $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $query->from;
+                    $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $query->getModel()->getTable();
 
                     $query->where(function (Builder $query) use ($relationColumns, $tableName, $searchValue) {
                         self::searchColumnQuery($query, $relationColumns, $tableName, $searchValue);

--- a/src/Http/Controllers/Filters/WhereIn.php
+++ b/src/Http/Controllers/Filters/WhereIn.php
@@ -56,7 +56,7 @@ class WhereIn extends Filter
         $relation = Table::getRelation($query->getModel()::class, $relationParts);
 
         $query->whereHas($relationPath, function (Builder $subQuery) use ($actualColumn, $values, $relation) {
-            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $subQuery->from;
+            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $subQuery->getModel()->getTable();
             $fullColumn = $tableName . '.' . $actualColumn;
 
             $subQuery->whereIn($fullColumn, $values);

--- a/src/Http/Controllers/Filters/WhereNotIn.php
+++ b/src/Http/Controllers/Filters/WhereNotIn.php
@@ -56,7 +56,7 @@ class WhereNotIn extends Filter
         $relation = Table::getRelation($query->getModel()::class, $relationParts);
 
         $query->whereHas($relationPath, function (Builder $subQuery) use ($actualColumn, $values, $relation) {
-            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $subQuery->from;
+            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $subQuery->getModel()->getTable();
             $fullColumn = $tableName . '.' . $actualColumn;
 
             $subQuery->whereNotIn($fullColumn, $values);

--- a/src/Http/Controllers/Filters/Wheres.php
+++ b/src/Http/Controllers/Filters/Wheres.php
@@ -61,7 +61,7 @@ class Wheres extends Filter
         $relation = Table::getRelation($query->getModel()::class, $columnParts);
 
         $query->whereHas($relationPath, function (Builder $innerQuery) use ($actualColumn, $operator, $value, $relation) {
-            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $innerQuery->from;
+            $tableName = $relation instanceof BelongsToMany ? $relation->getTable() : $innerQuery->getModel()->getTable();
             $fullColumn = $tableName . '.' . $actualColumn;
 
             static::applyWhere($innerQuery, $fullColumn, $operator, $value);


### PR DESCRIPTION
Searching through a self-referential relation in `searchable()` produced invalid SQL, because `Search::searchColumnQuery()` used `$query->from` (which returns `table as alias` for self-relations) as the column prefix. Switched to `$query->getModel()->getTable()`, which returns the bare alias Laravel sets via `setTable()` and equals the normal table name for all other relations. `BelongsToMany` handling is unchanged.