### PR TITLE
Added native parameter, return, and property type declarations (and stricter PHPDoc generics) throughout the package

### DIFF
--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -6,9 +6,13 @@ on:
 jobs:
   laravel-pint:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: "laravel-pint"
-        uses: aglipanci/laravel-pint-action@latest
+        uses: aglipanci/laravel-pint-action@v2
         with:
           testMode: true
+          useComposer: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - Added `pestphp/pest`, `pestphp/pest-plugin-laravel` and `orchestra/testbench` composer packages for testing.
 - Added config for Pest and Orchestra Testbench to support writing tests.
 - Added github action to run pest tests.
+- Added native parameter, return, and property type declarations (and stricter PHPDoc generics) throughout the package.
 
 ### ⚠️ Breaking changes ⚠️
 - Removed support for `laravel/framework` versions 8, 9, 10 and 11. The minimum version is now 12.
+- Type declarations were added to overridable methods and properties. If you extend `Controller`, its CRUD traits (`HasIndex`, `HasShow`, `HasStore`, `HasUpdate`, `HasDestroy`), `BaseResource`, or the `Response`/`Item`/`Items` objects, overridden signatures and redeclared properties may need updating — and the `beforeIndex`, `afterIndex`, `beforeShow` and `afterShow` hooks no longer receive their argument by reference. See the [upgrade guide](UPGRADE.md) for the full list of changed signatures.
 
 ## v0.6.1
 - Fixed a bug where filtering through a self-referential relation (search, where, whereIn, whereNotIn) generated invalid SQL, because the related model's aliased table name (`table as alias`) was used as a column prefix instead of the alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 
 ### ⚠️ Breaking changes ⚠️
 - Removed support for `laravel/framework` versions 8, 9, 10 and 11. The minimum version is now 12.
-- Type declarations were added to overridable methods and properties. If you extend `Controller`, its CRUD traits (`HasIndex`, `HasShow`, `HasStore`, `HasUpdate`, `HasDestroy`), `BaseResource`, or the `Response`/`Item`/`Items` objects, overridden signatures and redeclared properties may need updating — and the `beforeIndex`, `afterIndex`, `beforeShow` and `afterShow` hooks no longer receive their argument by reference. See the [upgrade guide](UPGRADE.md) for the full list of changed signatures.
+- Type declarations were added to overridable methods and properties. If you extend `Controller`, its CRUD traits (`HasIndex`, `HasShow`, `HasStore`, `HasUpdate`, `HasDestroy`, `HasAction`), `DefaultFormRequest`, `BaseResource`, or the `Response`/`Item`/`Items` objects, overridden signatures and redeclared properties may need updating — and the `beforeIndex`, `afterIndex`, `beforeShow` and `afterShow` hooks no longer receive their argument by reference. See the [upgrade guide](UPGRADE.md) for the full list of changed signatures.
+- `Controller::$resource`, `Controller::$saveFillable` and `Controller::$forceSimplePagination` were widened from `protected` to `public`. Redeclaring them as `protected` in a subclass is a fatal error.
+- `Item::model()` and `Items::query()` now return `new static()` instead of `new self()`, so subclasses of `Item`/`Items` get an instance of themselves from these factories.
 
 ## v0.6.1
 - Fixed a bug where filtering through a self-referential relation (search, where, whereIn, whereNotIn) generated invalid SQL, because the related model's aliased table name (`table as alias`) was used as a column prefix instead of the alias.

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ composer require weapnl/laravel-junction dev-main
 
 
 ## Quick Start
+
 ```php
-// app/Http/Controllers/Api/UserController.php
 namespace App\Http\Controllers\Api;
 
+use Illuminate\Database\Eloquent\Model;
 use Weap\Junction\Http\Controllers\Controller;
 
 class UserController extends Controller
@@ -56,14 +57,20 @@ class UserController extends Controller
     /**
      * The class name of the model for which the controller should implement CRUD actions.
      *
-     * @var string
+     * @var class-string<Model>
      */
-    public $model = User::class;
+    public string $model = User::class;
 
     /**
-     * Define the relations which can be loaded in a request using "array" notation.
+     * Define the relations which can be loaded in a request using "dot" notation.
      *
-     * @return array
+     * Each entry is either:
+     * - a relation name (string value with an integer key).
+     * - a relation name mapped to a closure that constrains the relation's query (string key with a Closure value).
+     *
+     * Both forms may be mixed.
+     *
+     * @return array<int|string, string|Closure>
      */
     public function relations(): array
     {
@@ -88,9 +95,9 @@ To make the controller accessible through the api, you need to extend the `Weap\
 Defining the controller is pretty straightforward, check the [Quick start](#quick-start) section for a basic example. We will now go over some of the extra functionality.
 
 ```php
-// app/Http/Controllers/Api/UserController.php
 namespace App\Http\Controllers\Api;
 
+use Illuminate\Database\Eloquent\Model;
 use Weap\Junction\Http\Controllers\Controller; // Make sure to import the Controller class from the Weap/Junction package.
 
 class UserController extends Controller
@@ -98,21 +105,27 @@ class UserController extends Controller
     /**
      * The class name of the model for which the controller should implement CRUD actions.
      *
-     * @var string
+     * @var class-string<Model>
      */
-    public $model = User::class;
-    
-    /**
-     * The class name of Resource to be used for the show and index methods.
-     *
-     * @var string $resource
-     */
-    public $resource = UserResource::class;
+    public string $model = User::class;
 
     /**
-     * Define the relations which can be loaded in a request using "array" notation.
+     * The class name of the resource to be used for the index and show methods.
      *
-     * @return array
+     * @var class-string<BaseResource>
+     */
+    public string $resource = UserResource::class;
+
+    /**
+     * Define the relations which can be loaded in a request using "dot" notation.
+     *
+     * Each entry is either:
+     * - a relation name (string value with an integer key).
+     * - a relation name mapped to a closure that constrains the relation's query (string key with a Closure value).
+     *
+     * Both forms may be mixed.
+     *
+     * @return array<int|string, string|Closure>
      */
     public function relations(): array
     {
@@ -199,7 +212,7 @@ This method should return an array containing relations (dot-notation is support
 
 **Note**: When using dot-notation, if a closure is given for one of the higher-level relations in your controller, that closure will be applied to the query. For example with relations implemented like below, loading the relation `user.activities`, will apply the `isAdmin` scope to the user query.
 ```php
-public function relations()
+public function relations(): array
 {
     return [
         'user' => fn ($query) => $query->isAdmin(),
@@ -299,7 +312,7 @@ Example:
 class UserResource extends BaseResource
 {
     /**
-     * @return array|null
+     * @return array<int, string>|null
      */
     protected function availableAttributes(): ?array
     {
@@ -309,7 +322,7 @@ class UserResource extends BaseResource
     }
 
     /**
-     * @return array|null
+     * @return array<int, string>|null
      */
     protected function availableAccessors(): ?array
     {
@@ -319,7 +332,7 @@ class UserResource extends BaseResource
     }
 
     /**
-     * @return array|null
+     * @return array<string, class-string<BaseResource>>|null
      */
     protected function availableRelations(): ?array
     {
@@ -336,7 +349,7 @@ Add the action method in your controller:
 
 ```php
 /**
- * @param null|Model $model
+ * @param Model|null $model
  */
 protected function actionSomeName($model = null)
 {
@@ -369,11 +382,11 @@ To validate the incoming request, you can create a `FormRequest` and extend the 
 To validate the request, create a request file for your model and add this to the controller.
 ```php
 /**
- * The class name of FormRequest to be used for the store and update methods.
+ * The class name of the form request to be used for the store and update methods.
  *
- * @var string
+ * @var class-string<FormRequest>
  */
-public $formRequest = ModelRequest::class;
+public string $formRequest = DefaultFormRequest::class;
 ```
 
 - Add rules to the `rules()` method in the `ModelRequest`.
@@ -381,9 +394,9 @@ public $formRequest = ModelRequest::class;
 /**
  * Get the validation rules that apply to the request.
  *
- * @return array
+ * @return array<string, mixed>
  */
-public function rules()
+public function rules(): array
 {
     return [
         'first_name' => 'required',
@@ -391,11 +404,11 @@ public function rules()
 }
 
 /**
- * Define validation rule messages for store and update requests.
+ * Define validation rule messages for the store and update methods.
  *
- * @return array
+ * @return array<string, string>
  */
-public function messages()
+public function messages(): array
 {
     return [
         'first_name.required' => 'The first name is required.',
@@ -407,11 +420,11 @@ public function messages()
 By default, only validated attributes are saved when calling store/update routes. To save fillable attributes instead, set the following on your controller:
 ```php
 /**
- * Set to true to save fillable instead of validated attributes in store/update methods.
+ * Set to true to save fillable instead of validated attributes in the store and update methods.
  *
  * @var bool
  */
-protected $saveFillable = true;
+public bool $saveFillable = true;
 ```
 
 ### Using Temporary Media Files with [Spatie Medialibrary](https://spatie.be/docs/laravel-medialibrary/v11/introduction)

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ To validate the request, create a request file for your model and add this to th
  *
  * @var class-string<FormRequest>
  */
-public string $formRequest = DefaultFormRequest::class;
+public string $formRequest = ModelRequest::class;
 ```
 
 - Add rules to the `rules()` method in the `ModelRequest`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,3 +5,98 @@
 ### Requirements
 
 - Laravel 12 or higher
+
+### Type Hints
+
+Native parameter, return, and property types have been added throughout the package. PHP enforces that an overriding method's signature stays compatible with its parent, so if you have extended any of the classes or traits below and overridden one of these methods (or declared one of these properties), you **must** update your signature to match, otherwise PHP will throw a fatal error.
+
+The docblock-only changes (e.g. `array` → `array<string, mixed>`, `Builder` → `Builder<Model>`) are not enforced at runtime, but adopting them keeps your project passing static analysis.
+
+#### Controller
+
+If your controller extends `Weap\Junction\Http\Controllers\Controller`, update any properties and methods you have overridden:
+
+```php
+// Properties — these are now typed (and $resource / $saveFillable are now public)
+public $model;                          →  public string $model;
+public $usePolicy = false;              →  public bool $usePolicy = false;
+public $formRequest = /* ... */;        →  public string $formRequest = /* ... */;
+protected $resource = /* ... */;        →  public string $resource = /* ... */;
+protected $saveFillable = false;        →  public bool $saveFillable = false;
+
+// Methods — return types added
+public function relations()             →  public function relations(): array
+public function searchable()            →  public function searchable(): array
+public function rules()                 →  public function rules(): array        // now @deprecated (unused)
+public function messages()              →  public function messages(): array
+
+// Constructor — the $model parameter is now typed
+public function __construct($model = null)  →  public function __construct(?string $model = null)
+```
+
+`$resource` and `$saveFillable` were widened from `protected` to `public`. If your controller redeclares either as `protected`, change it to `public` — PHP does not allow narrowing a property's visibility in a subclass, so leaving it `protected` will throw a fatal error.
+
+Most controllers set the `$model` property rather than override the constructor, so this usually needs no action. If you *do* override `__construct()`, keep the parameter compatible (an untyped `$model` still works) and pass a model **class-string**. Passing anything other than a string or `null` now throws a `TypeError`.
+
+#### Controller traits (hook methods)
+
+The lifecycle hooks in the `HasIndex`, `HasShow`, `HasStore`, `HasUpdate`, and `HasDestroy` traits now declare parameter and return types. If you override any of them, update the signature:
+
+```php
+// HasIndex
+public function index()                              →  public function index(): AnonymousResourceCollection
+public function beforeIndex(Builder &$query)         →  public function beforeIndex(Builder $query): void
+public function afterIndex(Items &$items)            →  public function afterIndex(Items $items): void
+
+// HasShow
+public function show($id)                            →  public function show(int|string|Model $id): JsonResource
+public function beforeShow(Builder &$query)          →  public function beforeShow(Builder $query): void
+public function afterShow(Item &$item)               →  public function afterShow(Item $item): void
+
+// HasStore
+public function store()                              →  public function store(): JsonResponse
+public function beforeStore($valid, $invalid)        →  public function beforeStore(array $validAttributes, array $invalidAttributes): array
+public function afterStore($model, $valid, $invalid) →  public function afterStore(Model $model, array $validAttributes, array $invalidAttributes): Model
+
+// HasUpdate
+public function update($id)                          →  public function update(int|string|Model $id): JsonResponse
+public function beforeUpdate($model, $v, $i)         →  public function beforeUpdate(Model $model, array $validAttributes, array $invalidAttributes): array
+public function afterUpdate($model, $v, $i)          →  public function afterUpdate(Model $model, array $validAttributes, array $invalidAttributes): Model
+
+// HasDestroy
+public function destroy($id)                         →  public function destroy(int|string|Model $id): JsonResponse
+public function beforeDestroy(Model $model)          →  public function beforeDestroy(Model $model): void
+public function afterDestroy(Model $model)           →  public function afterDestroy(Model $model): Model
+```
+
+> **Behavioural change:** the `$query` / `$items` parameters on `beforeIndex`, `afterIndex`, `beforeShow`, and `afterShow` are **no longer passed by reference** (the `&` was removed). You can still mutate the builder/response object in place (it is an object), but reassigning the variable to a new instance inside the hook will no longer take effect. If you relied on `$query = ...;` inside one of these hooks, mutate the existing instance instead.
+
+#### Model trait
+
+If your model uses `HasDefaultAppends` and overrides `defaultAppends()`:
+
+```php
+public static function defaultAppends()  →  public static function defaultAppends(): array
+```
+
+#### Resources
+
+If you extend `Weap\Junction\Http\Controllers\Resources\BaseResource` and override any of these methods:
+
+```php
+public function toArray($request)        →  public function toArray(Request $request): array
+public function pluckFields(/* ... */)   →  public function pluckFields(?array $pluckAttributes = null, ?array $pluckAccessors = null, ?array $pluckRelations = null): static
+protected function availableAttributes() →  protected function availableAttributes(): ?array
+protected function availableAccessors()  →  protected function availableAccessors(): ?array
+protected function availableRelations()  →  protected function availableRelations(): ?array
+```
+
+`pluckFields()` now returns `static` instead of `$this` (a docblock change only, no code change required, but note it if you type-hint the return value).
+
+#### Custom filters
+
+If you have written a custom filter extending `Weap\Junction\Http\Controllers\Filters\Filter`, the abstract `apply()` signature is unchanged at the PHP level (it was already `apply(Controller $controller, Builder|Relation $query): void`). Only the docblock generics were tightened to `Builder<Model>|Relation<Model, Model, mixed>`; no code change is required.
+
+#### Response objects
+
+The fluent methods on `Response`, `Item`, and `Items` now return `static` instead of `self`/`$this`. This is backwards compatible for callers, but if you extended these classes and overrode `modify()`, update the return type to `static`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,7 @@
 
 ### Type Hints
 
-Native parameter, return, and property types have been added throughout the package. PHP enforces that an overriding method's signature stays compatible with its parent, so if you have extended any of the classes or traits below and overridden one of these methods (or declared one of these properties), you **must** update your signature to match, otherwise PHP will throw a fatal error.
+Native parameter, return, and property types have been added throughout the package. PHP enforces that an overriding method's signature stays compatible with the one it inherits, so if you have extended any of the classes below and overridden one of these methods (or redeclared one of these properties), you **must** update your signature to match, otherwise PHP will throw a fatal error.
 
 The docblock-only changes (e.g. `array` → `array<string, mixed>`, `Builder` → `Builder<Model>`) are not enforced at runtime, but adopting them keeps your project passing static analysis.
 
@@ -17,26 +17,27 @@ The docblock-only changes (e.g. `array` → `array<string, mixed>`, `Builder` �
 If your controller extends `Weap\Junction\Http\Controllers\Controller`, update any properties and methods you have overridden:
 
 ```php
-// Properties — these are now typed (and $resource / $saveFillable are now public)
-public $model;                          →  public string $model;
-public $usePolicy = false;              →  public bool $usePolicy = false;
-public $formRequest = /* ... */;        →  public string $formRequest = /* ... */;
-protected $resource = /* ... */;        →  public string $resource = /* ... */;
-protected $saveFillable = false;        →  public bool $saveFillable = false;
+// Properties — these are now typed (and $resource / $saveFillable / $forceSimplePagination are now public)
+public $model;                                  →  public string $model;
+public $usePolicy = false;                      →  public bool $usePolicy = false;
+public $formRequest = /* ... */;                →  public string $formRequest = /* ... */;
+protected $resource = /* ... */;                →  public string $resource = /* ... */;
+protected $saveFillable = false;                →  public bool $saveFillable = false;
+protected bool $forceSimplePagination = false;  →  public bool $forceSimplePagination = false;
 
 // Methods — return types added
 public function relations()             →  public function relations(): array
 public function searchable()            →  public function searchable(): array
 public function rules()                 →  public function rules(): array        // now @deprecated (unused)
-public function messages()              →  public function messages(): array
+public function messages()              →  public function messages(): array     // now @deprecated (unused)
 
 // Constructor — the $model parameter is now typed
 public function __construct($model = null)  →  public function __construct(?string $model = null)
 ```
 
-`$resource` and `$saveFillable` were widened from `protected` to `public`. If your controller redeclares either as `protected`, change it to `public` — PHP does not allow narrowing a property's visibility in a subclass, so leaving it `protected` will throw a fatal error.
+`$resource`, `$saveFillable` and `$forceSimplePagination` were widened from `protected` to `public`. If your controller redeclares any of them as `protected`, change it to `public` — PHP does not allow narrowing a property's visibility in a subclass, so leaving it `protected` will throw a fatal error.
 
-Most controllers set the `$model` property rather than override the constructor, so this usually needs no action. If you *do* override `__construct()`, keep the parameter compatible (an untyped `$model` still works) and pass a model **class-string**. Passing anything other than a string or `null` now throws a `TypeError`.
+Most controllers set the `$model` property rather than override the constructor, so this usually needs no action. If you *do* override `__construct()`, keep the parameter compatible (an untyped `$model` still works) and pass a model **class-string**. Passing a value that is neither `null` nor coercible to a string now throws a `TypeError`.
 
 #### Controller traits (hook methods)
 
@@ -49,7 +50,7 @@ public function beforeIndex(Builder &$query)         →  public function before
 public function afterIndex(Items &$items)            →  public function afterIndex(Items $items): void
 
 // HasShow
-public function show($id)                            →  public function show(int|string|Model $id): JsonResource
+public function show($id)                            →  public function show(int|string|Model $id): BaseResource
 public function beforeShow(Builder &$query)          →  public function beforeShow(Builder $query): void
 public function afterShow(Item &$item)               →  public function afterShow(Item $item): void
 
@@ -71,32 +72,78 @@ public function afterDestroy(Model $model)           →  public function afterD
 
 > **Behavioural change:** the `$query` / `$items` parameters on `beforeIndex`, `afterIndex`, `beforeShow`, and `afterShow` are **no longer passed by reference** (the `&` was removed). You can still mutate the builder/response object in place (it is an object), but reassigning the variable to a new instance inside the hook will no longer take effect. If you relied on `$query = ...;` inside one of these hooks, mutate the existing instance instead.
 
+#### Custom actions
+
+The `HasAction` trait is also composed into `Controller`. Your `actionSomeName()` methods are unaffected, but if you override any of the trait's own methods — most commonly `getActions()`, to restrict which actions are exposed — update the signature:
+
+```php
+public function action()                   →  public function action(): mixed
+protected function getActionMethod($name)  →  protected function getActionMethod(string $name): ?string
+protected function getActions()            →  protected function getActions(): Collection
+protected function getActionMethods()      →  protected function getActionMethods(): Collection
+```
+
+`getActionMethod()` is now declared `?string`. Its runtime behaviour is unchanged — it always returned a string — but its old docblock incorrectly claimed `Illuminate\Support\Stringable`. If you wrote code against that docblock and called `Stringable` methods on the result, it was already broken.
+
 #### Model trait
 
-If your model uses `HasDefaultAppends` and overrides `defaultAppends()`:
+If your model uses `HasDefaultAppends` and overrides `defaultAppends()`, no change is required — a method defined on your own class replaces the trait's without a compatibility check. Adding the return type is still recommended for consistency:
 
 ```php
 public static function defaultAppends()  →  public static function defaultAppends(): array
 ```
 
-#### Resources
+#### Form requests
 
-If you extend `Weap\Junction\Http\Controllers\Resources\BaseResource` and override any of these methods:
+If your form request extends `Weap\Junction\Http\Controllers\Requests\DefaultFormRequest` (as the README suggests) and overrides either of these hooks, add the `void` return type:
 
 ```php
-public function toArray($request)        →  public function toArray(Request $request): array
-public function pluckFields(/* ... */)   →  public function pluckFields(?array $pluckAttributes = null, ?array $pluckAccessors = null, ?array $pluckRelations = null): static
-protected function availableAttributes() →  protected function availableAttributes(): ?array
-protected function availableAccessors()  →  protected function availableAccessors(): ?array
-protected function availableRelations()  →  protected function availableRelations(): ?array
+protected function failedValidation(Validator $validator)  →  protected function failedValidation(Validator $validator): void
+protected function passedValidation()                      →  protected function passedValidation(): void
 ```
 
-`pluckFields()` now returns `static` instead of `$this` (a docblock change only, no code change required, but note it if you type-hint the return value).
+Your `rules()` and `messages()` methods are unaffected — `DefaultFormRequest` does not declare them.
 
 #### Custom filters
 
-If you have written a custom filter extending `Weap\Junction\Http\Controllers\Filters\Filter`, the abstract `apply()` signature is unchanged at the PHP level (it was already `apply(Controller $controller, Builder|Relation $query): void`). Only the docblock generics were tightened to `Builder<Model>|Relation<Model, Model, mixed>`; no code change is required.
+Two internal helpers on the built-in filters gained types, which only matters if you extended one of those classes and overrode them:
+
+```php
+// Filters\Relations
+protected static function getAccessorRelations(string $modelClass, array $accessors)  →  /* ... */: array
+
+// Filters\Wheres
+protected static function applyWhere($query, /* ... */)  →  protected static function applyWhere(Builder|Relation $query, /* ... */)
+```
+
+#### Validators
+
+`Validators\Appends::validate()` and `Validators\Relations::validate()` now declare `: array`. These are called internally by the filters; update the return type if you extended either class.
 
 #### Response objects
 
-The fluent methods on `Response`, `Item`, and `Items` now return `static` instead of `self`/`$this`. This is backwards compatible for callers, but if you extended these classes and overrode `modify()`, update the return type to `static`.
+The methods on `Response`, `Item`, and `Items` now return `static` instead of `self`/`$this`. This is backwards compatible for callers, but if you extended these classes and overrode any of them, update the return type to `static`:
+
+```php
+// Response
+abstract public function modify(Closure $param): self  →  abstract public function modify(Closure $param): static
+
+// Item
+public static function model(Model $model)             →  public static function model(Model $model): static
+public function modify(Closure $param): self           →  public function modify(Closure $param): static
+
+// Items
+public static function query(Builder $query): Items    →  public static function query(Builder $query): static
+public function simplePagination(bool $s): Items       →  public function simplePagination(bool $simplePagination): static
+public function enforceOrderByModelKey(/* ... */): Items  →  public function enforceOrderByModelKey(bool $enforceOrderByModelKey, ?string $direction = 'asc'): static
+public function get(): self                            →  public function get(): static
+public function modify(Closure $param): self           →  public function modify(Closure $param): static
+```
+
+> **Behavioural change:** `Item::model()` and `Items::query()` now instantiate `new static()` instead of `new self()`. If you extended `Item` or `Items`, these factories now return an instance of *your* subclass rather than the base class. This is what the docblocks always claimed; previously they silently returned the base class.
+
+`Items::page()` also takes a typed `int $perPage` now. It is `protected` and only called internally, so this only affects you if you overrode it.
+
+#### Route helper
+
+`Junction::resource()` (already `@deprecated` in favour of `Route::junctionResource()`) now declares `resource(string $uri, string $controller, array $only = [/* ... */]): void`. Callers passing anything other than a string URI, a string controller class, and an array of route names will now get a `TypeError`.

--- a/src/AttributeRelationCache.php
+++ b/src/AttributeRelationCache.php
@@ -5,14 +5,14 @@ namespace Weap\Junction;
 class AttributeRelationCache
 {
     /**
-     * @var array
+     * @var array<string, array<string, array<int|string, mixed>>>
      */
     protected array $relations = [];
 
     /**
      * @param string $class
      * @param string $function
-     * @param array $with
+     * @param array<int|string, mixed> $with
      * @return void
      */
     public function set(string $class, string $function, array $with): void
@@ -23,7 +23,7 @@ class AttributeRelationCache
     /**
      * @param string $class
      * @param string $function
-     * @return array|null
+     * @return array<int|string, mixed>|null
      */
     public function get(string $class, string $function): ?array
     {

--- a/src/Extensions/RelationExtension.php
+++ b/src/Extensions/RelationExtension.php
@@ -8,12 +8,12 @@ use Illuminate\Routing\Controller;
 class RelationExtension
 {
     /**
-     * @var array<Closure(array<string, Closure>|array<string>, Controller): array<string, Closure>|array<string>>
+     * @var array<Closure(array<string, Closure>|array<string>, Controller): (array<string, Closure>|array<string>|null)>
      */
     protected array $closures = [];
 
     /**
-     * @param Closure(array<string, Closure>|array<string>, Controller): array<string, Closure>|array<string> $closure
+     * @param Closure(array<string, Closure>|array<string>, Controller): (array<string, Closure>|array<string>|null) $closure
      * @return static
      */
     public function add(Closure $closure): static

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -125,6 +125,8 @@ class Controller extends BaseController
      * Define validation rule messages for the store and update methods.
      *
      * @return array<string, string>
+     *
+     * @deprecated Unused method
      */
     public function messages(): array
     {

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -2,7 +2,10 @@
 
 namespace Weap\Junction\Http\Controllers;
 
+use Closure;
 use Exception;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Routing\Controller as BaseController;
 use Weap\Junction\Http\Controllers\Requests\DefaultFormRequest;
 use Weap\Junction\Http\Controllers\Resources\BaseResource;
@@ -27,95 +30,103 @@ class Controller extends BaseController
     /**
      * The class name of the model for which the controller should implement CRUD actions.
      *
-     * @var string
+     * @var class-string<Model>
      */
-    public $model;
+    public string $model;
 
     /**
      * Determine whether to use the policy corresponding with the model.
      *
      * @var bool
      */
-    public $usePolicy = false;
+    public bool $usePolicy = false;
 
     /**
-     * The class name of FormRequest to be used for the store and update methods.
+     * The class name of the form request to be used for the store and update methods.
      *
-     * @var string
+     * @var class-string<FormRequest>
      */
-    public $formRequest = DefaultFormRequest::class;
+    public string $formRequest = DefaultFormRequest::class;
 
     /**
-     * The class name of Resource to be used for the show and index methods.
+     * The class name of the resource to be used for the index and show methods.
      *
-     * @var string
+     * @var class-string<BaseResource>
      */
-    protected $resource = BaseResource::class;
+    public string $resource = BaseResource::class;
 
     /**
-     * Set to true to save fillable instead of validated attributes in store/update methods.
-     *
-     * @var bool
-     */
-    protected $saveFillable = false;
-
-    /**
-     * Set to true to force simple pagination in index method.
+     * Set to true to save fillable instead of validated attributes in the store and update methods.
      *
      * @var bool
      */
-    protected bool $forceSimplePagination = false;
+    public bool $saveFillable = false;
 
     /**
-     * @param null $model
+     * Set to true to force simple pagination in the index method.
+     *
+     * @var bool
+     */
+    public bool $forceSimplePagination = false;
+
+    /**
+     * @param class-string<Model>|null $model
      *
      * @throws Exception
      */
-    public function __construct($model = null)
+    public function __construct(?string $model = null)
     {
-        $this->model = $this->model ?? $model;
-
-        if (! $this->model) {
+        if (! isset($this->model) && ! $model) {
             throw new Exception('Your controller should contain a property `model` to define which model to query for.');
         }
+
+        $this->model ??= $model;
     }
 
     /**
-     * Define the relations which can be loaded in a request using "array" notation.
+     * Define the relations which can be loaded in a request using "dot" notation.
      *
-     * @return array
+     * Each entry is either:
+     * - a relation name (string value with an integer key).
+     * - a relation name mapped to a closure that constrains the relation's query (string key with a Closure value).
+     *
+     * Both forms may be mixed.
+     *
+     * @return array<int|string, string|Closure>
      */
-    public function relations()
+    public function relations(): array
     {
         return [];
     }
 
     /**
-     * Define the searchable column which can be searched trough in a request using "array" notation.
+     * Define the searchable column which can be searched trough in a request using "dot" notation.
      *
-     * @return array
+     * @return array<int, string>
      */
-    public function searchable()
+    public function searchable(): array
     {
         return [];
     }
 
     /**
-     * Define validation rules for store and update requests.
+     * Define validation rules for the store and update methods.
      *
-     * @return array
+     * @return array<string, mixed>
+     *
+     * @deprecated Unused method
      */
-    public function rules()
+    public function rules(): array
     {
         return [];
     }
 
     /**
-     * Define validation rule messages for store and update requests.
+     * Define validation rule messages for the store and update methods.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
+    public function messages(): array
     {
         return [];
     }

--- a/src/Http/Controllers/Filters/Count.php
+++ b/src/Http/Controllers/Filters/Count.php
@@ -3,6 +3,7 @@
 namespace Weap\Junction\Http\Controllers\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
 use Weap\Junction\Http\Controllers\Validators\Relations as RelationsValidator;
@@ -11,7 +12,7 @@ class Count extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     public static function apply(Controller $controller, Builder|Relation $query): void
     {

--- a/src/Http/Controllers/Filters/Filter.php
+++ b/src/Http/Controllers/Filters/Filter.php
@@ -3,6 +3,7 @@
 namespace Weap\Junction\Http\Controllers\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
 
@@ -10,7 +11,7 @@ abstract class Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     abstract public static function apply(Controller $controller, Builder|Relation $query): void;
 }

--- a/src/Http/Controllers/Filters/Limit.php
+++ b/src/Http/Controllers/Filters/Limit.php
@@ -3,6 +3,7 @@
 namespace Weap\Junction\Http\Controllers\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
 
@@ -10,7 +11,7 @@ class Limit extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     public static function apply(Controller $controller, Builder|Relation $query): void
     {

--- a/src/Http/Controllers/Filters/Order.php
+++ b/src/Http/Controllers/Filters/Order.php
@@ -3,6 +3,7 @@
 namespace Weap\Junction\Http\Controllers\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use RuntimeException;
 use Weap\Junction\Http\Controllers\Controller;
@@ -11,7 +12,7 @@ class Order extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     public static function apply(Controller $controller, Builder|Relation $query): void
     {

--- a/src/Http/Controllers/Filters/Relations.php
+++ b/src/Http/Controllers/Filters/Relations.php
@@ -5,6 +5,7 @@ namespace Weap\Junction\Http\Controllers\Filters;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -18,7 +19,7 @@ class Relations extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     public static function apply(Controller $controller, Builder|Relation $query): void
     {
@@ -46,29 +47,30 @@ class Relations extends Filter
     }
 
     /**
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      * @param string $relation
-     * @param array|Closure|int $nestedRelations
-     * @param array $relationFilters
+     * @param array<int|string, mixed>|Closure|int $nestedRelations
+     * @param array<string, callable|null> $relationFilters
      * @return void
      */
     protected static function addWith(Builder|Relation $query, string $relation, array|Closure|int $nestedRelations, array $relationFilters): void
     {
-        $relationFilters = array_filter(Arr::mapWithKeys($relationFilters, fn ($closure, $filterRelation) => Str::startsWith($filterRelation, $relation) ? [Str::after($filterRelation, $relation) => $closure] : [$filterRelation => null]));
+        $relationFilters = array_filter(Arr::mapWithKeys($relationFilters, fn ($closure, $filterRelation): array => Str::startsWith($filterRelation, $relation) ? [Str::after($filterRelation, $relation) => $closure] : [$filterRelation => null]));
 
-        $query->with($relation, function (Builder|Relation $query) use ($nestedRelations, $relation, $relationFilters) {
+        $query->with($relation, function (Builder|Relation $query) use ($nestedRelations, $relationFilters) {
             $nestedRelations = is_array($nestedRelations) ? $nestedRelations : [$nestedRelations];
 
-            $currentRelationFilters = Arr::where($relationFilters, fn ($closure, $filterRelation) => ! Str::startsWith($filterRelation, '.'));
+            $currentRelationFilters = Arr::where($relationFilters, fn ($closure, $filterRelation): bool => ! Str::startsWith($filterRelation, '.'));
 
             foreach ($currentRelationFilters as $currentRelationFilter) {
                 $currentRelationFilter($query);
             }
 
-            $remainingRelationFilters = Arr::mapWithKeys($relationFilters, fn ($closure, $filterRelation) => Str::startsWith($filterRelation, '.') ? [Str::after($filterRelation, '.') => $closure] : [$filterRelation => null]);
+            $remainingRelationFilters = Arr::mapWithKeys($relationFilters, fn ($closure, $filterRelation): array => Str::startsWith($filterRelation, '.') ? [Str::after($filterRelation, '.') => $closure] : [$filterRelation => null]);
 
             foreach (is_array($nestedRelations) ? $nestedRelations : [] as $nestedRelation => $nestedRelations) {
                 if (is_string($nestedRelation)) {
+                    /** @var Builder<Model>|Relation<Model, Model, mixed> $query */
                     static::addWith($query, $nestedRelation, $nestedRelations, $remainingRelationFilters);
                 } elseif (is_callable($nestedRelations)) {
                     $nestedRelations($query);
@@ -79,10 +81,10 @@ class Relations extends Filter
 
     /**
      * @param class-string $modelClass
-     * @param array $accessors
-     * @return array
+     * @param array<string, mixed> $accessors
+     * @return array<string, mixed>
      */
-    protected static function getAccessorRelations(string $modelClass, array $accessors)
+    protected static function getAccessorRelations(string $modelClass, array $accessors): array
     {
         $relations = [];
 

--- a/src/Http/Controllers/Filters/Scopes.php
+++ b/src/Http/Controllers/Filters/Scopes.php
@@ -3,6 +3,7 @@
 namespace Weap\Junction\Http\Controllers\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
 use Weap\Junction\Http\Controllers\Validators\Scopes as ScopesValidator;
@@ -11,7 +12,7 @@ class Scopes extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     public static function apply(Controller $controller, Builder|Relation $query): void
     {

--- a/src/Http/Controllers/Filters/Search.php
+++ b/src/Http/Controllers/Filters/Search.php
@@ -16,7 +16,7 @@ class Search extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      */
     public static function apply(Controller $controller, Builder|Relation $query): void
     {
@@ -40,8 +40,8 @@ class Search extends Filter
     }
 
     /**
-     * @param Builder $query
-     * @param array $columns
+     * @param Builder<Model> $query
+     * @param array<string, mixed> $columns
      * @param string $tableName
      * @param string $searchValue
      * @return void

--- a/src/Http/Controllers/Filters/WhereIn.php
+++ b/src/Http/Controllers/Filters/WhereIn.php
@@ -4,6 +4,7 @@ namespace Weap\Junction\Http\Controllers\Filters;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
@@ -13,7 +14,7 @@ class WhereIn extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      *
      * @throws Exception
      */
@@ -35,9 +36,9 @@ class WhereIn extends Filter
     }
 
     /**
-     * @param Builder $query
+     * @param Builder<Model> $query
      * @param string $column
-     * @param array $values
+     * @param array<int|string, mixed> $values
      */
     protected static function traverse(Builder $query, string $column, array $values): void
     {

--- a/src/Http/Controllers/Filters/WhereNotIn.php
+++ b/src/Http/Controllers/Filters/WhereNotIn.php
@@ -4,6 +4,7 @@ namespace Weap\Junction\Http\Controllers\Filters;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Weap\Junction\Http\Controllers\Controller;
@@ -13,7 +14,7 @@ class WhereNotIn extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      *
      * @throws Exception
      */
@@ -35,9 +36,9 @@ class WhereNotIn extends Filter
     }
 
     /**
-     * @param Builder $query
+     * @param Builder<Model> $query
      * @param string $column
-     * @param array $values
+     * @param array<int|string, mixed> $values
      */
     protected static function traverse(Builder $query, string $column, array $values): void
     {

--- a/src/Http/Controllers/Filters/Wheres.php
+++ b/src/Http/Controllers/Filters/Wheres.php
@@ -4,6 +4,7 @@ namespace Weap\Junction\Http\Controllers\Filters;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use RuntimeException;
@@ -14,7 +15,7 @@ class Wheres extends Filter
 {
     /**
      * @param Controller $controller
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      *
      * @throws Exception
      */
@@ -40,7 +41,7 @@ class Wheres extends Filter
     }
 
     /**
-     * @param Builder|Relation $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      * @param string $column
      * @param string $operator
      * @param mixed $value
@@ -69,13 +70,13 @@ class Wheres extends Filter
     }
 
     /**
-     * @param $query
+     * @param Builder<Model>|Relation<Model, Model, mixed> $query
      * @param string $column
      * @param string $operator
      * @param mixed $value
      * @return void
      */
-    protected static function applyWhere($query, string $column, string $operator, mixed $value): void
+    protected static function applyWhere(Builder|Relation $query, string $column, string $operator, mixed $value): void
     {
         if ($value === null) {
             if (in_array($operator, ['!=', 'IS NOT'], true)) {

--- a/src/Http/Controllers/Helpers/Table.php
+++ b/src/Http/Controllers/Helpers/Table.php
@@ -2,6 +2,7 @@
 
 namespace Weap\Junction\Http\Controllers\Helpers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
@@ -10,8 +11,8 @@ class Table
     /**
      * @deprecated This function gives wrong table name for `morphTo` relation.
      *
-     * @param string $model
-     * @param array $relations
+     * @param class-string<Model> $model
+     * @param array<int, string> $relations
      * @return string
      */
     public static function getRelationTableName(string $model, array $relations): string
@@ -26,9 +27,9 @@ class Table
     }
 
     /**
-     * @param string $model
-     * @param array $relations
-     * @return Relation
+     * @param class-string<Model> $model
+     * @param array<int, string> $relations
+     * @return Relation<Model, Model, mixed>
      */
     public static function getRelation(string $model, array $relations): Relation
     {

--- a/src/Http/Controllers/Modifiers/Appends.php
+++ b/src/Http/Controllers/Modifiers/Appends.php
@@ -32,7 +32,7 @@ class Appends extends Modifier
 
     /**
      * @param Model $model
-     * @param array $fields
+     * @param array<int, string> $fields
      */
     public static function traverse(Model $model, array $fields): void
     {

--- a/src/Http/Controllers/Modifiers/HiddenFields.php
+++ b/src/Http/Controllers/Modifiers/HiddenFields.php
@@ -29,7 +29,7 @@ class HiddenFields extends Modifier
 
     /**
      * @param Model $model
-     * @param array $hiddenFields
+     * @param array<int, string> $hiddenFields
      */
     public static function traverse(Model $model, array $hiddenFields): void
     {

--- a/src/Http/Controllers/Requests/DefaultFormRequest.php
+++ b/src/Http/Controllers/Requests/DefaultFormRequest.php
@@ -12,7 +12,7 @@ use Weap\Junction\Junction;
 class DefaultFormRequest extends FormRequest
 {
     /**
-     * @return void
+     * @inheritDoc
      */
     protected function prepareForValidation(): void
     {
@@ -22,10 +22,9 @@ class DefaultFormRequest extends FormRequest
     }
 
     /**
-     * @param Validator $validator
-     * @return void
+     * @inheritDoc
      */
-    protected function failedValidation(Validator $validator)
+    protected function failedValidation(Validator $validator): void
     {
         if (config('media-library.disk_name') !== 'local') {
             $this->clearTempMediaFiles($this->all());
@@ -35,9 +34,9 @@ class DefaultFormRequest extends FormRequest
     }
 
     /**
-     * @return void
+     * @inheritDoc
      */
-    protected function passedValidation()
+    protected function passedValidation(): void
     {
         if (config('media-library.disk_name') !== 'local') {
             $this->clearTempMediaFiles($this->all());

--- a/src/Http/Controllers/Resources/BaseResource.php
+++ b/src/Http/Controllers/Resources/BaseResource.php
@@ -13,25 +13,25 @@ use Weap\Junction\Http\Controllers\Response\Items;
 class BaseResource extends JsonResource
 {
     /**
-     * @var array|null
+     * @var array<string, mixed>|null
      */
     protected ?array $pluckAttributes = null;
 
     /**
-     * @var array|null
+     * @var array<string, mixed>|null
      */
     protected ?array $pluckAccessors = null;
 
     /**
-     * @var array|null
+     * @var array<string, mixed>|null
      */
     protected ?array $pluckRelations = null;
 
     /**
      * @param Items $items
-     * @param array|null $pluckAttributes
-     * @param array|null $pluckAccessors
-     * @param array|null $pluckRelations
+     * @param array<string, mixed>|null $pluckAttributes
+     * @param array<string, mixed>|null $pluckAccessors
+     * @param array<string, mixed>|null $pluckRelations
      * @return AnonymousResourceCollection
      */
     public static function items(Items $items, ?array $pluckAttributes = null, ?array $pluckAccessors = null, ?array $pluckRelations = null): AnonymousResourceCollection
@@ -54,10 +54,10 @@ class BaseResource extends JsonResource
     }
 
     /**
-     * @param array|null $pluckAttributes
-     * @param array|null $pluckAccessors
-     * @param array|null $pluckRelations
-     * @return $this
+     * @param array<string, mixed>|null $pluckAttributes
+     * @param array<string, mixed>|null $pluckAccessors
+     * @param array<string, mixed>|null $pluckRelations
+     * @return static
      */
     public function pluckFields(?array $pluckAttributes = null, ?array $pluckAccessors = null, ?array $pluckRelations = null): static
     {
@@ -72,7 +72,7 @@ class BaseResource extends JsonResource
      * Transform the resource into an array.
      *
      * @param Request $request
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray(Request $request): array
     {
@@ -89,7 +89,7 @@ class BaseResource extends JsonResource
 
     /**
      * @param Request $request
-     * @return array
+     * @return array<string, mixed>
      */
     protected function relationsToArray(Request $request): array
     {
@@ -137,7 +137,7 @@ class BaseResource extends JsonResource
 
     /**
      * @param Request $request
-     * @return array
+     * @return array<string, mixed>
      */
     protected function attributesToArray(Request $request): array
     {
@@ -166,7 +166,7 @@ class BaseResource extends JsonResource
 
     /**
      * @param Request $request
-     * @return array
+     * @return array<string, mixed>
      */
     protected function accessorsToArray(Request $request): array
     {
@@ -201,7 +201,7 @@ class BaseResource extends JsonResource
     }
 
     /**
-     * @return array|null
+     * @return array<int, string>|null
      */
     protected function availableAttributes(): ?array
     {
@@ -209,7 +209,7 @@ class BaseResource extends JsonResource
     }
 
     /**
-     * @return array|null
+     * @return array<int, string>|null
      */
     protected function availableAccessors(): ?array
     {
@@ -217,7 +217,7 @@ class BaseResource extends JsonResource
     }
 
     /**
-     * @return array|null
+     * @return array<string, class-string<BaseResource>>|null
      */
     protected function availableRelations(): ?array
     {

--- a/src/Http/Controllers/Response/Item.php
+++ b/src/Http/Controllers/Response/Item.php
@@ -14,11 +14,11 @@ class Item extends Response
 
     /**
      * @param Model $model
-     * @return self
+     * @return static
      */
-    public static function model(Model $model): self
+    public static function model(Model $model): static
     {
-        $item = new self();
+        $item = new static();
 
         $item->model = $model;
 

--- a/src/Http/Controllers/Response/Item.php
+++ b/src/Http/Controllers/Response/Item.php
@@ -14,9 +14,9 @@ class Item extends Response
 
     /**
      * @param Model $model
-     * @return static
+     * @return self
      */
-    public static function model(Model $model)
+    public static function model(Model $model): self
     {
         $item = new self();
 
@@ -27,9 +27,9 @@ class Item extends Response
 
     /**
      * @param Closure $param
-     * @return $this
+     * @return static
      */
-    public function modify(Closure $param): self
+    public function modify(Closure $param): static
     {
         $param($this->model);
 

--- a/src/Http/Controllers/Response/Items.php
+++ b/src/Http/Controllers/Response/Items.php
@@ -5,22 +5,23 @@ namespace Weap\Junction\Http\Controllers\Response;
 use Closure;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Enumerable;
 
 class Items extends Response
 {
     /**
-     * @var Builder
+     * @var Builder<Model>
      */
     protected Builder $query;
 
     /**
-     * @var Enumerable
+     * @var Enumerable<int, Model>
      */
     protected Enumerable $models;
 
     /**
-     * @var Paginator|null
+     * @var Paginator<int, Model>|null
      */
     protected ?Paginator $paginator = null;
 
@@ -40,10 +41,10 @@ class Items extends Response
     protected ?string $enforceOrderByModelKeyDirection = null;
 
     /**
-     * @param Builder $query
-     * @return Items
+     * @param Builder<Model> $query
+     * @return self
      */
-    public static function query(Builder $query): Items
+    public static function query(Builder $query): self
     {
         $items = new self();
 
@@ -54,9 +55,9 @@ class Items extends Response
 
     /**
      * @param bool $simplePagination
-     * @return $this
+     * @return static
      */
-    public function simplePagination(bool $simplePagination): Items
+    public function simplePagination(bool $simplePagination): static
     {
         $this->simplePagination = $simplePagination;
 
@@ -66,9 +67,9 @@ class Items extends Response
     /**
      * @param bool $enforceOrderByModelKey
      * @param string|null $direction
-     * @return $this
+     * @return static
      */
-    public function enforceOrderByModelKey(bool $enforceOrderByModelKey, ?string $direction = 'asc'): Items
+    public function enforceOrderByModelKey(bool $enforceOrderByModelKey, ?string $direction = 'asc'): static
     {
         $this->enforceOrderByModelKey = $enforceOrderByModelKey;
         $this->enforceOrderByModelKeyDirection = $direction;
@@ -77,9 +78,9 @@ class Items extends Response
     }
 
     /**
-     * @return $this
+     * @return static
      */
-    public function get(): self
+    public function get(): static
     {
         $columns = [$this->query->getModel()->getTable() . '.*'];
         $perPage = request()?->input('paginate');
@@ -107,9 +108,9 @@ class Items extends Response
 
     /**
      * @param Closure $param
-     * @return $this
+     * @return static
      */
-    public function modify(Closure $param): self
+    public function modify(Closure $param): static
     {
         $this->models->each($param);
 
@@ -117,7 +118,7 @@ class Items extends Response
     }
 
     /**
-     * @return Enumerable
+     * @return Enumerable<int, Model>
      */
     public function models(): Enumerable
     {
@@ -125,7 +126,7 @@ class Items extends Response
     }
 
     /**
-     * @return Paginator|null
+     * @return Paginator<int, Model>|null
      */
     public function paginator(): ?Paginator
     {
@@ -133,10 +134,10 @@ class Items extends Response
     }
 
     /**
-     * @param $perPage
+     * @param int $perPage
      * @return int|null
      */
-    protected function page($perPage): ?int
+    protected function page(int $perPage): ?int
     {
         $page = request()?->input('page') ?: 1;
 
@@ -164,7 +165,7 @@ class Items extends Response
             return $page;
         }
 
-        return ceil(($index + 1) / $perPage);
+        return (int) ceil(($index + 1) / $perPage);
     }
 
     /**

--- a/src/Http/Controllers/Response/Items.php
+++ b/src/Http/Controllers/Response/Items.php
@@ -42,11 +42,11 @@ class Items extends Response
 
     /**
      * @param Builder<Model> $query
-     * @return self
+     * @return static
      */
-    public static function query(Builder $query): self
+    public static function query(Builder $query): static
     {
-        $items = new self();
+        $items = new static();
 
         $items->query = $query;
 

--- a/src/Http/Controllers/Response/Response.php
+++ b/src/Http/Controllers/Response/Response.php
@@ -8,7 +8,7 @@ abstract class Response
 {
     /**
      * @param Closure $param
-     * @return $this
+     * @return static
      */
-    abstract public function modify(Closure $param): self;
+    abstract public function modify(Closure $param): static;
 }

--- a/src/Http/Controllers/Traits/HasAction.php
+++ b/src/Http/Controllers/Traits/HasAction.php
@@ -2,6 +2,7 @@
 
 namespace Weap\Junction\Http\Controllers\Traits;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
@@ -12,11 +13,11 @@ use Weap\Junction\Http\Controllers\Helpers\Database;
 trait HasAction
 {
     /**
-     * @return \Illuminate\Http\JsonResponse
+     * @return mixed
      *
      * @throws Throwable
      */
-    public function action()
+    public function action(): mixed
     {
         request()->validate([
             'action' => [
@@ -25,7 +26,7 @@ trait HasAction
             ],
         ]);
 
-        $actionMethod = $this->getActionMethod(request()->action);
+        $actionMethod = $this->getActionMethod((string) request()->action);
         $requiresModel = $this->actionRequiresModel($actionMethod);
 
         if ($requiresModel) {
@@ -52,13 +53,13 @@ trait HasAction
     }
 
     /**
-     * @param $name
-     * @return \Illuminate\Support\Stringable
+     * @param string $name
+     * @return string|null
      */
-    protected function getActionMethod($name)
+    protected function getActionMethod(string $name): ?string
     {
-        $exists = (bool) $this->getActions()->first(function ($action) use ($name) {
-            return $action == $name;
+        $exists = (bool) $this->getActions()->first(function (string $action) use ($name) {
+            return $action === $name;
         });
 
         return $exists
@@ -67,19 +68,19 @@ trait HasAction
     }
 
     /**
-     * @return \Illuminate\Support\Collection
+     * @return Collection<int, string>
      */
-    protected function getActions()
+    protected function getActions(): Collection
     {
-        return $this->getActionMethods()->map(function ($method) {
+        return $this->getActionMethods()->map(function (string $method) {
             return (string) Str::of($method)->remove('action')->camel();
         });
     }
 
     /**
-     * @return \Illuminate\Support\Collection
+     * @return Collection<int, non-falsy-string>
      */
-    protected function getActionMethods()
+    protected function getActionMethods(): Collection
     {
         return collect(get_class_methods($this))->filter(function ($method) {
             return Str::of($method)->startsWith('action')

--- a/src/Http/Controllers/Traits/HasAction.php
+++ b/src/Http/Controllers/Traits/HasAction.php
@@ -78,7 +78,7 @@ trait HasAction
     }
 
     /**
-     * @return Collection<int, non-falsy-string>
+     * @return Collection<int, string>
      */
     protected function getActionMethods(): Collection
     {

--- a/src/Http/Controllers/Traits/HasDefaultAppends.php
+++ b/src/Http/Controllers/Traits/HasDefaultAppends.php
@@ -7,7 +7,7 @@ trait HasDefaultAppends
     /**
      * Add this trait to your model if you want to include all accessors defined in `$appends` in the response.
      *
-     * @return array
+     * @return array<int, string>
      */
     public static function defaultAppends(): array
     {

--- a/src/Http/Controllers/Traits/HasDestroy.php
+++ b/src/Http/Controllers/Traits/HasDestroy.php
@@ -16,7 +16,7 @@ trait HasDestroy
      *
      * @throws Throwable
      */
-    public function destroy($id)
+    public function destroy(int|string|Model $id): JsonResponse
     {
         if ($id instanceof Model) {
             $id = $id->{$id->getKeyName()};
@@ -46,7 +46,7 @@ trait HasDestroy
     /**
      * @param Model $model
      */
-    public function beforeDestroy(Model $model)
+    public function beforeDestroy(Model $model): void
     {
         //
     }
@@ -55,7 +55,7 @@ trait HasDestroy
      * @param Model $model
      * @return Model
      */
-    public function afterDestroy(Model $model)
+    public function afterDestroy(Model $model): Model
     {
         return $model;
     }

--- a/src/Http/Controllers/Traits/HasIndex.php
+++ b/src/Http/Controllers/Traits/HasIndex.php
@@ -3,6 +3,7 @@
 namespace Weap\Junction\Http\Controllers\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
@@ -27,7 +28,7 @@ trait HasIndex
      *
      * @throws Throwable
      */
-    public function index()
+    public function index(): AnonymousResourceCollection
     {
         if ($this->usePolicy && ! Auth::user()->can('viewAny', $this->model)) {
             abort(403, 'Unauthorized');
@@ -39,7 +40,7 @@ trait HasIndex
             abort(400, 'Simple pagination is required for this resource.');
         }
 
-        /** @var Builder $query */
+        /** @var Builder<Model> $query */
         $query = $this->model::query();
 
         $this->beforeIndex($query);
@@ -80,9 +81,9 @@ trait HasIndex
     }
 
     /**
-     * @param Builder $query
+     * @param Builder<Model> $query
      */
-    public function beforeIndex(Builder &$query)
+    public function beforeIndex(Builder $query): void
     {
         //
     }
@@ -90,7 +91,7 @@ trait HasIndex
     /**
      * @param Items $items
      */
-    public function afterIndex(Items &$items)
+    public function afterIndex(Items $items): void
     {
         //
     }

--- a/src/Http/Controllers/Traits/HasShow.php
+++ b/src/Http/Controllers/Traits/HasShow.php
@@ -26,7 +26,7 @@ trait HasShow
      *
      * @throws Exception
      */
-    public function show($id)
+    public function show(int|string|Model $id): BaseResource
     {
         if ($id instanceof Model) {
             $id = $id->{$id->getKeyName()};
@@ -74,9 +74,9 @@ trait HasShow
     }
 
     /**
-     * @param Builder $query
+     * @param Builder<Model> $query
      */
-    public function beforeShow(Builder &$query)
+    public function beforeShow(Builder $query): void
     {
         //
     }
@@ -84,7 +84,7 @@ trait HasShow
     /**
      * @param Item $item
      */
-    public function afterShow(Item &$item)
+    public function afterShow(Item $item): void
     {
         //
     }

--- a/src/Http/Controllers/Traits/HasStore.php
+++ b/src/Http/Controllers/Traits/HasStore.php
@@ -5,6 +5,7 @@ namespace Weap\Junction\Http\Controllers\Traits;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Throwable;
 use Weap\Junction\Http\Controllers\Helpers\Database;
@@ -12,11 +13,11 @@ use Weap\Junction\Http\Controllers\Helpers\Database;
 trait HasStore
 {
     /**
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      *
      * @throws Throwable
      */
-    public function store()
+    public function store(): JsonResponse
     {
         if ($this->usePolicy && ! Auth::user()->can('create', $this->model)) {
             abort(403, 'Unauthorized');
@@ -48,22 +49,22 @@ trait HasStore
     }
 
     /**
-     * @param array $validAttributes
-     * @param array $invalidAttributes
-     * @return array
+     * @param array<string, mixed> $validAttributes
+     * @param array<string, mixed> $invalidAttributes
+     * @return array<string, mixed>
      */
-    public function beforeStore(array $validAttributes, array $invalidAttributes)
+    public function beforeStore(array $validAttributes, array $invalidAttributes): array
     {
         return $validAttributes;
     }
 
     /**
      * @param Model $model
-     * @param array $validAttributes
-     * @param array $invalidAttributes
+     * @param array<string, mixed> $validAttributes
+     * @param array<string, mixed> $invalidAttributes
      * @return Model
      */
-    public function afterStore(Model $model, array $validAttributes, array $invalidAttributes)
+    public function afterStore(Model $model, array $validAttributes, array $invalidAttributes): Model
     {
         return $model;
     }

--- a/src/Http/Controllers/Traits/HasUpdate.php
+++ b/src/Http/Controllers/Traits/HasUpdate.php
@@ -5,6 +5,7 @@ namespace Weap\Junction\Http\Controllers\Traits;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Throwable;
 use Weap\Junction\Http\Controllers\Helpers\Database;
@@ -13,11 +14,11 @@ trait HasUpdate
 {
     /**
      * @param int|string|Model $id
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      *
      * @throws Throwable
      */
-    public function update($id)
+    public function update(int|string|Model $id): JsonResponse
     {
         if ($id instanceof Model) {
             $id = $id->{$id->getKeyName()};
@@ -59,22 +60,22 @@ trait HasUpdate
 
     /**
      * @param Model $model
-     * @param array $validAttributes
-     * @param array $invalidAttributes
-     * @return array
+     * @param array<string, mixed> $validAttributes
+     * @param array<string, mixed> $invalidAttributes
+     * @return array<string, mixed>
      */
-    public function beforeUpdate(Model $model, array $validAttributes, array $invalidAttributes)
+    public function beforeUpdate(Model $model, array $validAttributes, array $invalidAttributes): array
     {
         return $validAttributes;
     }
 
     /**
      * @param Model $model
-     * @param array $validAttributes
-     * @param array $invalidAttributes
+     * @param array<string, mixed> $validAttributes
+     * @param array<string, mixed> $invalidAttributes
      * @return Model
      */
-    public function afterUpdate(Model $model, array $validAttributes, array $invalidAttributes)
+    public function afterUpdate(Model $model, array $validAttributes, array $invalidAttributes): Model
     {
         return $model;
     }

--- a/src/Http/Controllers/Validators/Appends.php
+++ b/src/Http/Controllers/Validators/Appends.php
@@ -10,12 +10,12 @@ class Appends
 {
     /**
      * @param Controller $controller
-     * @param array $appends
-     * @return array
+     * @param array<int, string> $appends
+     * @return array<int, string>
      *
      * @throws ValidationException
      */
-    public static function validate(Controller $controller, array $appends)
+    public static function validate(Controller $controller, array $appends): array
     {
         $appends = collect($appends);
 

--- a/src/Http/Controllers/Validators/Relations.php
+++ b/src/Http/Controllers/Validators/Relations.php
@@ -15,12 +15,12 @@ class Relations
      * Ex. `['relation' => function($query){ return $query; }]`
      *
      * @param Controller $controller
-     * @param array $relations
-     * @return array
+     * @param array<int|string, mixed> $relations
+     * @return array<int|string, mixed>
      *
      * @throws ValidationException
      */
-    public static function validate(Controller $controller, array $relations)
+    public static function validate(Controller $controller, array $relations): array
     {
         $relations = collect($relations);
 

--- a/src/Http/Controllers/Validators/Scopes.php
+++ b/src/Http/Controllers/Validators/Scopes.php
@@ -9,8 +9,8 @@ class Scopes
 {
     /**
      * @param Controller $controller
-     * @param array $scopes
-     * @return array
+     * @param array<int, array<string, mixed>> $scopes
+     * @return array<int, array<string, mixed>>
      *
      * @throws ValidationException
      */

--- a/src/Junction.php
+++ b/src/Junction.php
@@ -17,14 +17,14 @@ class Junction
     }
 
     /**
-     * @param $uri
-     * @param $controller
-     * @param mixed $only
+     * @param string $uri
+     * @param class-string $controller
+     * @param array<int, string> $only
      * @return void
      *
      * @deprecated Replaced by Route::junctionResource().
      */
-    public static function resource($uri, $controller, $only = ['index', 'indexPost', 'store', 'show', 'showPost', 'update', 'destroy', 'action']): void
+    public static function resource(string $uri, string $controller, array $only = ['index', 'indexPost', 'store', 'show', 'showPost', 'update', 'destroy', 'action']): void
     {
         Route::junctionResource($uri, $controller)->only($only);
     }
@@ -32,8 +32,8 @@ class Junction
     /**
      * @param callable|null $get
      * @param callable|null $set
-     * @param array $with
-     * @return Attribute
+     * @param array<int|string, mixed> $with
+     * @return Attribute<mixed, mixed>
      */
     public static function makeAttribute(?callable $get = null, ?callable $set = null, array $with = []): Attribute
     {

--- a/src/Models/MediaTemporaryUpload.php
+++ b/src/Models/MediaTemporaryUpload.php
@@ -12,7 +12,7 @@ class MediaTemporaryUpload extends Model implements HasMedia
     use InteractsWithMedia;
 
     /**
-     * @return BelongsTo
+     * @return BelongsTo<Model, $this>
      */
     public function createdBy(): BelongsTo
     {

--- a/src/ResourceRegistrar.php
+++ b/src/ResourceRegistrar.php
@@ -23,7 +23,7 @@ class ResourceRegistrar extends BaseResourceRegistrar
      * @param string $name
      * @param string $base
      * @param string $controller
-     * @param array $options
+     * @param array<string, mixed> $options
      * @return Route
      */
     protected function addResourceIndexPost(string $name, string $base, string $controller, array $options): Route
@@ -44,7 +44,7 @@ class ResourceRegistrar extends BaseResourceRegistrar
      * @param string $name
      * @param string $base
      * @param string $controller
-     * @param array $options
+     * @param array<string, mixed> $options
      * @return Route
      */
     protected function addResourceShowPost(string $name, string $base, string $controller, array $options): Route
@@ -65,7 +65,7 @@ class ResourceRegistrar extends BaseResourceRegistrar
      * @param string $name
      * @param string $base
      * @param string $controller
-     * @param array $options
+     * @param array<string, mixed> $options
      * @return Route
      */
     public function addResourceAction(string $name, string $base, string $controller, array $options): Route


### PR DESCRIPTION
## Changes
- Added native parameter, return, and property type declarations (and stricter PHPDoc generics) throughout the package.

## ⚠️ Breaking changes ⚠️
- Type declarations were added to overridable methods and properties. If you extend `Controller`, its CRUD traits (`HasIndex`, `HasShow`, `HasStore`, `HasUpdate`, `HasDestroy`), `BaseResource`, or the `Response`/`Item`/`Items` objects, overridden signatures and redeclared properties may need updating — and the `beforeIndex`, `afterIndex`, `beforeShow` and `afterShow` hooks no longer receive their argument by reference. See the [upgrade guide](UPGRADE.md) for the full list of changed signatures.